### PR TITLE
fix a bug of room_type spec

### DIFF
--- a/spec/dummy-apartment_spec.rb
+++ b/spec/dummy-apartment_spec.rb
@@ -103,7 +103,7 @@ describe DummyApartment do
     end
 
     it 'should be match the format' do
-      expect(room_type).to match /\A\d[LDK]{1,3}\z/
+      expect(room_type).to match /\A\d(R|[LDK]{1,3})\z/
     end
   end
 


### PR DESCRIPTION
The regxp was /\A\d[LDK]{1,3}\z/.
It did not cover "1R", so fix it to /\A\d(R|[LDK]{1,3})\z/
